### PR TITLE
Fix potentially problematic specialArgs

### DIFF
--- a/archive/flake.nix
+++ b/archive/flake.nix
@@ -20,7 +20,9 @@
       # Configuration for dev-config
       "dev-config" = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = inputs;
+        specialArgs = {
+          inherit inputs;
+        };
         modules = [
           ./configuration.nix
 


### PR DESCRIPTION
If you do `specialArgs = inputs`, then in every module you get each of the inputs separately. That is, you would get something like

```nix
{config, pkgs, nixpkgs, nixpkgs-unstable, home-manager, ...}:
```

This PR makes it so that everything is collapsed under `inputs`. and you get this in your modules:

```nix
{config, pkgs, inputs, ...}:
```

Additionally this way you can add more special arguments to your modules :)